### PR TITLE
historyの参照渡しを修正

### DIFF
--- a/bot/cogs/chat.py
+++ b/bot/cogs/chat.py
@@ -26,7 +26,7 @@ class ReplyButton(discord.ui.Button):
     async def callback(self, interaction: discord.Interaction):
         modal = ReplyModal(
             original_itx=interaction,
-            history=self.history
+            history=self.history.copy()
         )
         await interaction.response.send_modal(modal)
 

--- a/bot/gemini.py
+++ b/bot/gemini.py
@@ -8,7 +8,7 @@ import mimetypes
 import tempfile
 
 GEMINI_API_KEY = os.environ.get("GEMINI_API_KEY", "")
-MODEL = os.environ.get("GEMINI_API_KEY", "gemini-2.5-flash")
+MODEL = os.environ.get("MODEL", "gemini-2.5-flash")
 IMAGE_MODEL = os.environ.get("IMAGE_MODEL", "gemini-2.0-flash-preview-image-generation")
 
 client = genai.Client(api_key=GEMINI_API_KEY)


### PR DESCRIPTION
### historyを常に参照渡ししていたので過去のhistoryが最新のhistoryで更新されていた
- ButtonからModalを宣言するときにコピーして渡すように修正